### PR TITLE
rotating carousel for card recommendation - POC

### DIFF
--- a/src/pages/root/root.module.scss
+++ b/src/pages/root/root.module.scss
@@ -1,0 +1,106 @@
+$perspective: 1000px;
+$spinTime: 0.5s;
+
+.Wrapper {
+  height: 300px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+}
+
+.Slider {
+  position: relative;
+  width: 150px;
+  aspect-ratio: 1 / 1.58;
+  transform-style: preserve-3d;
+  transform: perspective($perspective);
+
+  span {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    transform-origin: center;
+    transform-style: preserve-3d;
+    transform: rotateY(calc(var(--i) * 180deg)) translateZ(150px);
+
+    img {
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      border-radius: 8px;
+      box-shadow: 2px 2px 4px 0px rgba(0, 0, 0, 0.35);
+      -webkit-box-shadow: 2px 2px 4px 0px rgba(0, 0, 0, 0.35);
+      -moz-box-shadow: 2px 2px 4px 0px rgba(0, 0, 0, 0.35);
+    }
+  }
+}
+
+.SpinLeft {
+  animation: rotateLeft $spinTime linear;
+}
+
+@keyframes rotateLeft {
+  0% {
+    transform: perspective($perspective) rotateY(0deg);
+  }
+  100% {
+    transform: perspective($perspective) rotateY(-180deg);
+  }
+}
+
+.SpinRight {
+  animation: rotateRight $spinTime linear;
+}
+
+@keyframes rotateRight {
+  0% {
+    transform: perspective($perspective) rotateY(0deg);
+  }
+  100% {
+    transform: perspective($perspective) rotateY(180deg);
+  }
+}
+
+.FadeOut {
+  animation: fadeOut $spinTime linear;
+}
+
+@keyframes fadeOut {
+  0% {
+    opacity: 1;
+  }
+  49% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 0;
+  }
+}
+
+.FadeIn {
+  animation: fadeIn $spinTime linear;
+}
+
+@keyframes fadeIn {
+  0% {
+    opacity: 0;
+  }
+  49% {
+    opacity: 0;
+  }
+  50% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 1;
+  }
+}

--- a/src/pages/root/root.tsx
+++ b/src/pages/root/root.tsx
@@ -1,14 +1,142 @@
-import { useQuery } from 'react-query';
+import React from 'react';
 import Spacing from '../../components/spacing';
-import { getMe } from '../remotes';
+import classes from './root.module.scss';
+
+const imageArray = [
+  'https://fastly.picsum.photos/id/1060/200/300.jpg?hmac=xYtFmeYcfydIF3-Qybnra-tMwklX69T52EtGd-bacBI',
+  'https://fastly.picsum.photos/id/1077/200/300.jpg?hmac=BqQneQETTwZkHqmZmg4VxHsD-Lia-Qxp6nXv0c2eaac',
+  'https://fastly.picsum.photos/id/756/200/300.jpg?hmac=kojqQY60yVD4KaSEFOEw62LRuwfiOR2f-6ZdnEgKhxM',
+  'https://fastly.picsum.photos/id/385/200/300.jpg?hmac=IG8cHDliDmlgbSYX1yquX_5cAHcuS_O378oPs5rZGrU',
+  'https://fastly.picsum.photos/id/979/200/300.jpg?hmac=VPyKJONiCJZ0uDkMSUYGHAmGqBjjH307k7K8AOmqQSM',
+];
+
+const testarr = ['1', '2', '3', '4'];
 
 export function Root() {
-  const { data } = useQuery('getMe', getMe);
+  const sliderRef = React.useRef<HTMLDivElement>(null);
+  const [cardIndex, setCardIndex] = React.useState(0);
+  const [isSpinning, setIsSpinning] = React.useState<
+    'toLeft' | 'toRight' | 'idle'
+  >('idle');
+  const fowardCardSrcRef = React.useRef(imageArray[cardIndex]);
+  const backgroundCardSrcRef = React.useRef(imageArray[cardIndex + 1]);
+
+  React.useEffect(() => {
+    const slider = sliderRef.current;
+
+    const onAnimationEnd = () => {
+      setIsSpinning('idle');
+    };
+
+    const onAnimationStart = () => {
+      if (isSpinning === 'toLeft') {
+        fowardCardSrcRef.current = imageArray[cardIndex];
+        backgroundCardSrcRef.current = imageArray[cardIndex - 1];
+      } else if (isSpinning === 'toRight') {
+        fowardCardSrcRef.current = imageArray[cardIndex];
+        backgroundCardSrcRef.current = imageArray[cardIndex + 1];
+      }
+    };
+
+    slider?.addEventListener('animationend', onAnimationEnd);
+    slider?.addEventListener('animationstart', onAnimationStart);
+
+    return () => {
+      slider?.removeEventListener('animationend', onAnimationEnd);
+      slider?.removeEventListener('animationstart', onAnimationStart);
+    };
+  }, [cardIndex, isSpinning]);
+
+  const setSliderAnimation = () => {
+    if (isSpinning === 'toLeft') {
+      return classes.SpinLeft;
+    } else if (isSpinning === 'toRight') {
+      return classes.SpinRight;
+    }
+
+    return '';
+  };
+
+  const setFowardCardOpacity = () => {
+    if (isSpinning !== 'idle') {
+      return classes.FadeOut;
+    }
+
+    return '';
+  };
+
+  const setBackgroundCardOpacity = () => {
+    if (isSpinning !== 'idle') {
+      return classes.FadeIn;
+    }
+
+    return '';
+  };
 
   return (
     <>
       <Spacing size={20} />
-      {data?.name ?? '-'}
+      <div className={classes.Wrapper}>
+        <div
+          ref={sliderRef}
+          className={[classes.Slider, setSliderAnimation()].join(' ')}
+        >
+          <span style={{ '--i': 1 } as React.CSSProperties}>
+            <img
+              alt={testarr[cardIndex - 1]}
+              src={backgroundCardSrcRef.current}
+              draggable={false}
+              className={[setBackgroundCardOpacity()].join(' ')}
+            />
+          </span>
+          <span style={{ '--i': 2 } as React.CSSProperties}>
+            <img
+              alt={testarr[cardIndex]}
+              src={fowardCardSrcRef.current}
+              draggable={false}
+              className={[setFowardCardOpacity()].join(' ')}
+            />
+          </span>
+        </div>
+      </div>
+      <div
+        style={{ display: 'flex', justifyContent: 'center', margin: '0 auto' }}
+      >
+        <button
+          onClick={() => {
+            if (isSpinning === 'idle') {
+              setIsSpinning('toLeft');
+
+              setCardIndex((prev) => {
+                if (prev <= 0) {
+                  return imageArray.length - 1;
+                }
+
+                return prev - 1;
+              });
+            }
+          }}
+        >
+          {'<'}
+        </button>
+        <button
+          onClick={() => {
+            if (isSpinning === 'idle') {
+              setIsSpinning('toRight');
+
+              setCardIndex((prev) => {
+                if (prev >= imageArray.length - 1) {
+                  return 0;
+                }
+
+                return prev + 1;
+              });
+            }
+          }}
+        >
+          {'>'}
+        </button>
+      </div>
     </>
   );
 }


### PR DESCRIPTION
### Preview

|  ![chrome-capture-2023-9-21](https://github.com/Lee-Si-Yoon/ts-credit-replica/assets/76679207/c4ff1e7d-5719-480d-acfb-83dfcb5b1314) |
| ------- |

## This PR solves

implementing rotating carousel

## I tried to solve problem by

I attempted to achieve this by using two image tags positioned to face each other on a cylindrical surface. The idea was to rotate the cylinder upon a button click event. However, this implementation has two issues

1. controlling the index of content will not be easy

Because this implementation relies on two indexes from the data array, we need to think twice. In the next PR I'll aim to use just a single index

2. image flickering

https://github.com/Lee-Si-Yoon/ts-credit-replica/blob/5bae1089bfd8bc94a24640b7926f13c966b4d55c/src/pages/root/root.module.scss#L48-L55

The cylinder's rotation animation currently rotates only 180 degrees, which causes image flickering. This happens because during the animation, the forward card moves behind the background card and then gets reset during the 'animationEnd' event. To resolve this issue, I'll need to switch the order of the image tags after every 'animationEnd' event. In my opinion, this isn't a straightforward solution

<br/>